### PR TITLE
Fix typo of metal name in the metallurgy menu

### DIFF
--- a/localisation/DA_Interface_l_english.yml
+++ b/localisation/DA_Interface_l_english.yml
@@ -206,7 +206,7 @@
  DA_Metal_Shower_Colored_Tin_30_44: "[DA_Metal_owned_Tin.GetValue]"
  DA_Metal_Shower_Colored_Tin_45: "§G[DA_Metal_owned_Tin.GetValue]§!"
 
- DA_Metal_Shower.Aluminium:0 "Alluminium       [DA_Metal_Shower_Colored_Aluminium]"
+ DA_Metal_Shower.Aluminium:0 "Aluminium       [DA_Metal_Shower_Colored_Aluminium]"
  DA_Metal_Shower_Colored_Aluminium_0_14: "§R[DA_Metal_owned_Aluminium.GetValue]§!"
  DA_Metal_Shower_Colored_Aluminium_15_29: "§Y[DA_Metal_owned_Aluminium.GetValue]§!"
  DA_Metal_Shower_Colored_Aluminium_30_44: "[DA_Metal_owned_Aluminium.GetValue]"


### PR DESCRIPTION
fix: Aluminium typo in the Metallurgy interface

Aluminium accidentally typo'd in the Metallurgy interface with two 'L' characters